### PR TITLE
add model methods for daily review nuggets

### DIFF
--- a/nuggetsapp/models.py
+++ b/nuggetsapp/models.py
@@ -20,11 +20,11 @@ class Nugget(models.Model):
 
     @classmethod
     def get_nuggets_by_user(cls, user):
-        return Nugget_User.get_nuggets_by_user(user)
+        return [x.nugget for x in Nugget_User.get_nugget_users_by_user(user)] 
         
     @classmethod
     def get_todays_review_nuggets_by_user(cls, user):
-        return Nugget_User.get_todays_review_nuggets_by_user(user)
+        return [x.nugget for x in Nugget_User.get_todays_review_nugget_users_by_user(user)] 
 
     @classmethod
     def create_new_nugget(cls, user, text, tags, source):
@@ -65,14 +65,18 @@ class Nugget_User(models.Model):
                 is_deleted=False)
 
     @classmethod
-    def get_nuggets_by_user(cls, user):
-        return [x.nugget for x in cls.objects.filter(Q(user = user) & Q(is_deleted = False))]
+    def get_nugget_users_by_user(cls, user, exclude_deleted = True):
+        q_objects = Q(user = user)
+        q_objects.add(Q(is_deleted = False), Q.AND) if exclude_deleted
+        return cls.objects.filter(q_objects)
                 
     @classmethod
-    def get_todays_review_nuggets_by_user(cls, user):
+    def get_todays_review_nugget_users_by_user(cls, user, exclude_deleted = True):
         review_interval_days = [1, 3, 7, 14, 30, 90, 180, 360, 720]
-        review_dates = [date_for_days_from_today(n) for n in review_interval_days]
-        return [x.nugget for x in  cls.objects.filter(Q(user = user) & Q(is_deleted = False) & Q(created_at__date__in = review_dates))]
+        review_dates = [date_for_x_days_before_today(n) for n in review_interval_days]
+        q_objects = Q(user = user) & Q(created_at__date__in = review_dates)
+        q_objects.add(Q(is_deleted = False), Q.AND) if exclude_deleted
+        return cls.objects.filter(q_objects)
      
     
 

--- a/nuggetsapp/models.py
+++ b/nuggetsapp/models.py
@@ -1,6 +1,9 @@
 from django.db import models
 from django.utils import timezone
 from django.contrib.auth.models import User
+import datetime
+from datetime import timedelta
+
 
 class Nugget(models.Model):
     owner = models.ForeignKey('auth.User')
@@ -18,6 +21,10 @@ class Nugget(models.Model):
     @classmethod
     def get_nuggets_by_user(cls, user):
         return Nugget_User.get_nuggets_by_user(user)
+        
+    @classmethod
+    def get_todays_review_nuggets_by_user(cls, user):
+        return Nugget_User.get_todays_review_nuggets_by_user(user)
 
     @classmethod
     def create_new_nugget(cls, user, text, tags, source):
@@ -59,5 +66,21 @@ class Nugget_User(models.Model):
 
     @classmethod
     def get_nuggets_by_user(cls, user):
-        return [x.nugget for x in cls.objects.filter(user = user)]
+        return [x.nugget for x in cls.objects.filter(user = user).filter(is_deleted = False)]
+        
+    @classmethod
+    def get_todays_review_nuggets_by_user(cls, user):
+        today = datetime.date.today(); 
+        one_day_back = today - timedelta(days=1); 
+        three_days_back = today - timedelta(days = 3); 
+        one_week_back = today - timedelta(days = 7); 
+        two_weeks_back = today - timedelta(days = 14); 
+        one_month_back = today - timedelta(days = 30); 
+        three_months_back = today - timedelta(days = 3 * 30)
+        six_months_back = today - timedelta(days = 6 * 30)
+        one_year_back = today - timedelta(days = 12 * 30)
+        two_years_back = today - timedelta(days = 24 * 30)
+ 
+        return [x.nugget for x in  cls.objects.filter(Q(user = user) & Q(is_deleted = False) & (Q(created_at__date__gte = one_day_back) | Q(created_at__date__in = [three_days_back, one_week_back, two_weeks_back, one_month_back, three_months_back, six_months_back, one_year_back, two_years_back])))]
+     
 

--- a/nuggetsapp/models.py
+++ b/nuggetsapp/models.py
@@ -2,8 +2,7 @@ from django.db import models
 from django.utils import timezone
 from django.contrib.auth.models import User
 from django.db.models import Q
-from utils import date_for_days_from_today
-
+from utils import date_for_x_days_before_today
 
 class Nugget(models.Model):
     owner = models.ForeignKey('auth.User')
@@ -19,12 +18,12 @@ class Nugget(models.Model):
         return self.text
 
     @classmethod
-    def get_nuggets_by_user(cls, user):
-        return [x.nugget for x in Nugget_User.get_nugget_users_by_user(user)] 
+    def get_nuggets_by_user(cls, user, exclude_deleted =True)
+        return [x.nugget for x in Nugget_User.get_nugget_users_by_user(user, exclude_deleted)] 
         
     @classmethod
-    def get_todays_review_nuggets_by_user(cls, user):
-        return [x.nugget for x in Nugget_User.get_todays_review_nugget_users_by_user(user)] 
+    def get_todays_review_nuggets_by_user(cls, user, exclude_deleted =True)
+        return [x.nugget for x in Nugget_User.get_todays_review_nugget_users_by_user(user, exclude_deleted)] 
 
     @classmethod
     def create_new_nugget(cls, user, text, tags, source):
@@ -65,18 +64,16 @@ class Nugget_User(models.Model):
                 is_deleted=False)
 
     @classmethod
-    def get_nugget_users_by_user(cls, user, exclude_deleted = True):
+    def get_nugget_users_by_user(cls, user, exclude_deleted =True):
         q_objects = Q(user = user)
         q_objects.add(Q(is_deleted = False), Q.AND) if exclude_deleted
         return cls.objects.filter(q_objects)
                 
     @classmethod
-    def get_todays_review_nugget_users_by_user(cls, user, exclude_deleted = True):
+    def get_todays_review_nugget_users_by_user(cls, user, exclude_deleted =True):
         review_interval_days = [1, 3, 7, 14, 30, 90, 180, 360, 720]
         review_dates = [date_for_x_days_before_today(n) for n in review_interval_days]
         q_objects = Q(user = user) & Q(created_at__date__in = review_dates)
         q_objects.add(Q(is_deleted = False), Q.AND) if exclude_deleted
         return cls.objects.filter(q_objects)
      
-    
-

--- a/nuggetsapp/models.py
+++ b/nuggetsapp/models.py
@@ -1,8 +1,8 @@
 from django.db import models
 from django.utils import timezone
 from django.contrib.auth.models import User
-import datetime
-from datetime import timedelta
+from django.db.models import Q
+from utils import date_for_days_from_today
 
 
 class Nugget(models.Model):
@@ -66,21 +66,13 @@ class Nugget_User(models.Model):
 
     @classmethod
     def get_nuggets_by_user(cls, user):
-        return [x.nugget for x in cls.objects.filter(user = user).filter(is_deleted = False)]
-        
+        return [x.nugget for x in cls.objects.filter(Q(user = user) & Q(is_deleted = False))]
+                
     @classmethod
     def get_todays_review_nuggets_by_user(cls, user):
-        today = datetime.date.today(); 
-        one_day_back = today - timedelta(days=1); 
-        three_days_back = today - timedelta(days = 3); 
-        one_week_back = today - timedelta(days = 7); 
-        two_weeks_back = today - timedelta(days = 14); 
-        one_month_back = today - timedelta(days = 30); 
-        three_months_back = today - timedelta(days = 3 * 30)
-        six_months_back = today - timedelta(days = 6 * 30)
-        one_year_back = today - timedelta(days = 12 * 30)
-        two_years_back = today - timedelta(days = 24 * 30)
- 
-        return [x.nugget for x in  cls.objects.filter(Q(user = user) & Q(is_deleted = False) & (Q(created_at__date__gte = one_day_back) | Q(created_at__date__in = [three_days_back, one_week_back, two_weeks_back, one_month_back, three_months_back, six_months_back, one_year_back, two_years_back])))]
+        review_interval_days = [1, 3, 7, 14, 30, 90, 180, 360, 720]
+        review_dates = [date_for_days_from_today(n) for n in review_interval_days]
+        return [x.nugget for x in  cls.objects.filter(Q(user = user) & Q(is_deleted = False) & Q(created_at__date__in = review_dates))]
      
+    
 

--- a/nuggetsapp/models.py
+++ b/nuggetsapp/models.py
@@ -73,7 +73,7 @@ class Nugget_User(models.Model):
     def get_todays_review_nugget_users_by_user(cls, user, exclude_deleted =True):
         review_interval_days = [1, 3, 7, 14, 30, 90, 180, 360, 720]
         review_dates = [date_for_x_days_before_today(n) for n in review_interval_days]
-        q_objects = Q(user = user) & Q(created_at__date__in = review_dates)
+        q_objects = Q(user = user) & Q(created_at__date__in = review_dates) #__date casts the datetime value as date
         q_objects.add(Q(is_deleted = False), Q.AND) if exclude_deleted
         return cls.objects.filter(q_objects)
-     
+

--- a/nuggetsapp/utils.py
+++ b/nuggetsapp/utils.py
@@ -1,6 +1,6 @@
 import datetime
 
-def date_for_days_before_today(dayCount): 
+def date_for_x_days_before_today(dayCount): 
         today = datetime.date.today() 
         return today - datetime.timedelta(days=dayCount)
         

--- a/nuggetsapp/utils.py
+++ b/nuggetsapp/utils.py
@@ -3,4 +3,4 @@ import datetime
 def date_for_x_days_before_today(dayCount): 
         today = datetime.date.today() 
         return today - datetime.timedelta(days=dayCount)
-        
+       

--- a/nuggetsapp/utils.py
+++ b/nuggetsapp/utils.py
@@ -2,4 +2,4 @@ import datetime
 
 def date_for_days_from_today(dayCount): 
         today = datetime.date.today(); 
-        return today - datetime.timedelta(days=dayCount);
+        return today - datetime.timedelta(days=dayCount)

--- a/nuggetsapp/utils.py
+++ b/nuggetsapp/utils.py
@@ -1,5 +1,6 @@
 import datetime
 
-def date_for_days_from_today(dayCount): 
-        today = datetime.date.today(); 
+def date_for_days_before_today(dayCount): 
+        today = datetime.date.today() 
         return today - datetime.timedelta(days=dayCount)
+        

--- a/nuggetsapp/utils.py
+++ b/nuggetsapp/utils.py
@@ -1,0 +1,5 @@
+import datetime
+
+def date_for_days_from_today(dayCount): 
+        today = datetime.date.today(); 
+        return today - datetime.timedelta(days=dayCount);


### PR DESCRIPTION
- Adds a model method to get a list of nuggets that has to be reviewed by the user today. 
- This method will be called by the daily reminder generation cron job or by the front-end client to display "today's review" tab

Logic for selecting review nuggets for today: 
- Include any nuggets created or added  by user since yesterday
- Include any nuggets created or added by user 3 days back, 1 week back, 2 weeks back, 1 month back, 3 months back, 6 months back, 1 year back, 2 years back. 
- Don't include any deleted nuggets
