### PR TITLE
Add more rest methods for nuggets

### DIFF
--- a/nuggetsapp/api_controllers.py
+++ b/nuggetsapp/api_controllers.py
@@ -1,0 +1,50 @@
+from nuggetsapp.serializers import NuggetSerializer
+from rest_framework.decorators import api_view
+from rest_framework import status
+from rest_framework.response import Response
+from django.contrib.auth.models import User
+from nuggetsapp.models import Nugget
+
+@api_view(['GET', 'POST'])
+def nuggets_op_by_user(request, user_id):
+    try:
+        user = User.objects.get(id=user_id)
+    except User.DoesNotExist:
+        return Response(status=status.HTTP_404_NOT_FOUND)
+
+    if request.method == 'GET':
+        nuggets = Nugget.get_nuggets_by_user(user)
+        serializer = NuggetSerializer(nuggets, many=True)
+        return Response(serializer.data)
+
+    elif request.method == 'POST':
+        serializer = NuggetSerializer(user, data=request.data)
+        if serializer.is_valid():
+            Nugget.create_new_nugget(user, serializer.validated_data['text'], serializer.validated_data['tags'], serializer.validated_data['source'])
+            return Response(serializer.data)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+@api_view(['DELETE', 'PUT', 'GET'])
+def nuggets_op_by_user_and_nugget(request, user_id, nugget_id):
+    try:
+        user = User.objects.get(id=user_id)
+    except User.DoesNotExist:
+        return Response(status=status.HTTP_404_NOT_FOUND)
+
+    try:
+        nugget = Nugget.objects.get(id=nugget_id)
+    except Nugget.DoesNotExist:
+        return Response(status=status.HTTP_404_NOT_FOUND)
+
+    if request.method == 'GET':
+        serializer = NuggetSerializer(nugget, many=False)
+        return Response(serializer.data)
+
+    elif request.method == 'PUT':
+        serializer = NuggetSerializer(user, data=request.data)
+        if serializer.is_valid():
+            return Response(Nugget.update_nugget(user, nugget, serializer.validated_data['text']))
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    elif request.method == 'DELETE':
+        return Response(Nugget.delete_nugget(user, nugget))

--- a/nuggetsapp/serializers.py
+++ b/nuggetsapp/serializers.py
@@ -3,6 +3,11 @@ from rest_framework import serializers
 
 
 class NuggetSerializer(serializers.ModelSerializer):
+    def validate(self, data):
+        if len(data['text']) > Nugget.MAX_TEXT_SIZE:
+            raise serializers.ValidationError("Nugget text larger than 200 limit")
+        return data
+
     class Meta:
         model = Nugget
-        fields = ('owner_name', 'source', 'text', 'url', 'tags', 'created_at', 'updated_at', 'is_deleted')
+        fields = ('id', 'owner_name', 'source', 'text', 'url', 'tags', 'created_at', 'updated_at', 'is_deleted')

--- a/nuggetsapp/urls.py
+++ b/nuggetsapp/urls.py
@@ -1,8 +1,9 @@
 from django.conf.urls import url, include
-from . import views
+from . import views, api_controllers
 
 urlpatterns = [
-    url(r'^api/v1/nuggets/(?P<user_id>[0-9]+)/$', views.nuggets_for_user, name='nuggets_for_user'),
+    url(r'^api/v0/user/(?P<user_id>[0-9]+)/nuggets/$', api_controllers.nuggets_op_by_user, name='nuggets_op_by_user'),
+    url(r'^api/v0/user/(?P<user_id>[0-9]+)/nuggets/(?P<nugget_id>[0-9]+)$', api_controllers.nuggets_op_by_user_and_nugget, name='nuggets_op_by_user_and_nugget'),
     url(r'^api-auth/', include('rest_framework.urls')),
 
     url(r'^$', views.home, name='home'),

--- a/nuggetsapp/views.py
+++ b/nuggetsapp/views.py
@@ -1,10 +1,7 @@
 from django.shortcuts import render
 from django.contrib.auth import authenticate, login as auth_login
 from django.contrib.auth.decorators import login_required
-from rest_framework.decorators import api_view
-from rest_framework.response import Response
 from nuggetsapp.models import Nugget
-from nuggetsapp.serializers import NuggetSerializer
 import logging
 logger = logging.getLogger(__name__)
 
@@ -43,8 +40,3 @@ def my_nuggets(request):
     nuggets = Nugget.get_nuggets_by_user(request.user.id)
     return render(request, 'nuggetsapp/my-nuggets.html', {'nuggets': nuggets})
 
-@api_view(['GET'])
-def nuggets_for_user(request, user_id):
-    nuggets = Nugget.get_nuggets_by_user(user_id)
-    serializer = NuggetSerializer(nuggets, many=True)
-    return Response(serializer.data)


### PR DESCRIPTION
@nathanwchan @aswath87 

I've added PUT/POST/DELETE methods for nuggets (still no auth though). So after this change, we have:

GET api/v0/user/1/nuggets/  - which will get all nuggets for a user
PUT api/v0/user/1/nuggets/  - which will add new nuggets for a user (the nugget data will be part of the body of the request)
POST api/v0/user/1/nuggets/1  - which will update a single nugget's text
DELETE api/v0/user/1/nuggets/1  - which will delete a single nugget

Please let me know what you think!
