### PR TITLE
Add token auth

### DIFF
--- a/nuggets/settings.py
+++ b/nuggets/settings.py
@@ -36,7 +36,8 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'nuggetsapp',
-    'rest_framework'
+    'rest_framework',
+    'rest_framework.authtoken'
 )
 
 MIDDLEWARE_CLASSES = (
@@ -143,3 +144,13 @@ STATICFILES_DIRS = [
 # Simplified static file serving.
 # https://warehouse.python.org/project/whitenoise/
 STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
+
+REST_FRAMEWORK = {
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated',
+    ),
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.TokenAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+    )
+}

--- a/nuggetsapp/models.py
+++ b/nuggetsapp/models.py
@@ -97,3 +97,6 @@ class Nugget_User(models.Model):
     @classmethod
     def delete_nugget_user(cls, user, nugget):
         Nugget_User.objects.filter(user = user, nugget = nugget).update(is_deleted = True)
+
+
+import signals

--- a/nuggetsapp/signals.py
+++ b/nuggetsapp/signals.py
@@ -1,0 +1,11 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from rest_framework.authtoken.models import Token
+from django.conf import settings
+
+
+# This code is triggered whenever a new user has been created and saved to the database
+@receiver(post_save, sender=settings.AUTH_USER_MODEL)
+def create_auth_token(sender, instance=None, created=False, **kwargs):
+    if created:
+        Token.objects.create(user=instance)

--- a/nuggetsapp/urls.py
+++ b/nuggetsapp/urls.py
@@ -1,10 +1,12 @@
 from django.conf.urls import url, include
+from rest_framework.authtoken import views as authviews
 from . import views, api_controllers
 
 urlpatterns = [
     url(r'^api/v0/user/(?P<user_id>[0-9]+)/nuggets/$', api_controllers.nuggets_op_by_user, name='nuggets_op_by_user'),
     url(r'^api/v0/user/(?P<user_id>[0-9]+)/nuggets/(?P<nugget_id>[0-9]+)$', api_controllers.nuggets_op_by_user_and_nugget, name='nuggets_op_by_user_and_nugget'),
     url(r'^api-auth/', include('rest_framework.urls')),
+    url(r'^api-token-auth/', authviews.obtain_auth_token),
 
     url(r'^$', views.home, name='home'),
     url(r'^login$', views.login, name='login'),


### PR DESCRIPTION
@nathanwchan @aswath87 

This PR adds token auth to the endpoints. This is how it works:

First, when a user is created, a new token is added for that user in the `authtoken_token` table:

```
nuggetsdb=# select * from authtoken_token;
                   key                    |            created            | user_id
------------------------------------------+-------------------------------+---------
 d3a73927cf1922d16ba68e56d614cac800547f93 | 2016-07-06 10:00:49.078203-04 |       5
 70b06bacf7497b033b32767314ad2ebedff7dad7 | 2016-07-06 10:05:35.339403-04 |       1
(2 rows)
```

Then, the client requests the token for the user by passing the username and password: 

```
$ curl -XPOST http://localhost:8000/api-token-auth/ -d 'username=karthik.kumar&password=Pa55word!' | jq .
{
  "token": "70b06bacf7497b033b32767314ad2ebedff7dad7"
}
```

Then, with this token, the client can request nuggets:

```
$ curl -XGET http://localhost:8000/api/v0/user/3/nuggets/ -H 'Authorization: Token 70b06bacf7497b033b32767314ad2ebedff7dad7' | jq .
[
  {
    "id": 4,
    "owner_name": "abcde",
    "source": "some source",
    "text": "hello world updatedddddddd",
    "url": "www.someurl.com",
    "tags": "sometag",
    "created_at": "2016-07-05T14:18:26Z",
    "updated_at": "2016-07-05T14:18:26Z",
    "is_deleted": false
  }
]
```

Without a valid token, the client gets a 401 Unauthorized:

```
$ curl -XGET http://localhost:8000/api/v0/user/3/nuggets/ -H 'Authorization: Token badtoken' | jq .
{
  "detail": "Invalid token."
}
```

There is a still a problem with this implementation, which is that once a client has  a single token, he/she can request/update nuggets for any user, not only theirs. So we still need to add checks to make sure that a user is only requesting/updating nuggets that belong to them
